### PR TITLE
Fix incorrect logical operator causing JACK backend...

### DIFF
--- a/rtmidi17/detail/jack.hpp
+++ b/rtmidi17/detail/jack.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#if __has_include(<weak_libjack.h>) && __has_include(<jack/jack.h>)
+#if __has_include(<weak_libjack.h>) || __has_include(<jack/jack.h>)
 
 #if __has_include(<weak_libjack.h>)
   #include <weak_libjack.h>

--- a/rtmidi17/rtmidi17.cpp
+++ b/rtmidi17/rtmidi17.cpp
@@ -6,7 +6,7 @@
 #endif
 
 #include <rtmidi17/detail/midi_api.hpp>
-#if  !__has_include(<weak_libjack.h>) || !__has_include(<jack/jack.h>) 
+#if  !__has_include(<weak_libjack.h>) && !__has_include(<jack/jack.h>) 
   #if defined(RTMIDI17_JACK)
     #undef RTMIDI17_JACK
   #endif


### PR DESCRIPTION
...be disabled in certain situations.

This should (hopefully) allow it to be built on FreeBSD/OpenBSD with functional support.