### PR TITLE
Reader bugfixes

### DIFF
--- a/include/rtmidi17/reader.cpp
+++ b/include/rtmidi17/reader.cpp
@@ -108,7 +108,7 @@ parseEvent(int tick, int track, uint8_t const*& dataStart, message_type lastEven
 
   track_event event{tick, track, message{}};
 
-  if (((uint8_t)type & 0xF) == 0xF)
+  if (((uint8_t)type & 0xF0) == 0xF0)
   {
     // Meta event
     if ((uint8_t)type == 0xFF)

--- a/include/rtmidi17/reader.cpp
+++ b/include/rtmidi17/reader.cpp
@@ -383,11 +383,11 @@ void reader::parse_impl(const std::vector<uint8_t>& buffer)
 
       if (useAbsoluteTicks)
       {
-        tickCount += tick;
+        tickCount = tick;
       }
       else
       {
-        tickCount = tick;
+        tickCount += tick;
       }
 
       try


### PR DESCRIPTION
Corrections to bitmask, tick counting logic to read standard MIDI files.

This addresses issue #21 and issue #22.